### PR TITLE
Optimize travis ci build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: ruby
 dist: trusty
 rvm:
-  - 2.5.1
+  - 2.3.1
 env:
   - DB=mysql
   - DB=postgresql

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ dist: trusty
 rvm:
   - 2.3.1
 env:
-  - DB=mysql
-  - DB=postgresql
   - DB=sqlite
 bundler_args: --without capistrano doc production --jobs 2
 before_script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.3.1
 
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs file imagemagick git && \


### PR DESCRIPTION
### Context

Production server uses Ruby 2.3.1 version and sqlite as database. Since we decided to not maintain compatibility with `frab` project, we do not need to execute different Ruby versions or different databases.