### PR TITLE
Prepare old users to new Attendance system

### DIFF
--- a/db/migrate/20181004182357_migrate_old_attendance_status_to_attendance_status.rb
+++ b/db/migrate/20181004182357_migrate_old_attendance_status_to_attendance_status.rb
@@ -1,0 +1,40 @@
+class MigrateOldAttendanceStatusToAttendanceStatus < ActiveRecord::Migration
+  def up
+    conference = find_past_conference
+    unless conference
+      Rails.logger.info "Conference IFF2018 not found. Nothing to migrate"
+      return
+    end
+
+    Person.where(old_attendance_status: 'confirmed').each do |person|
+      Rails.logger.info "Migrating #{person.email}"
+
+      AttendanceStatus.create(
+        person: person,
+        conference: conference,
+        status: AttendanceStatus::REGISTERED
+      )
+    end
+  end
+
+  def down
+    conference = find_past_conference
+    unless conference
+      Rails.logger.info "Conference IFF2018 not found. Nothing to migrate"
+      return
+    end
+
+    AttendanceStatus.where(status: AttendanceStatus::REGISTERED, conference: conference).each do |attendance|
+      Rails.logger.info "Migrating #{person.email}"
+
+      person = attendance.person
+      person.update_attributes(old_attendance_status: 'confirmed')
+    end
+  end
+
+  private
+
+  def find_past_conference
+    Conference.find_by(acronym: 'IFF2018')
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181001135519) do
+ActiveRecord::Schema.define(version: 20181004182357) do
 
   create_table "attendance_statuses", force: :cascade do |t|
     t.string   "status"


### PR DESCRIPTION
### Context

Old system managed attendance by `attendance_status` field in `Person`. With the new Attendance system we must migrate previous attendants to the new model `AttendanceStatus`.