### PR TITLE
Remove duplicate sentence from session submit form

### DIFF
--- a/app/views/cfp/events/_form.html.haml
+++ b/app/views/cfp/events/_form.html.haml
@@ -7,7 +7,7 @@
       %li.form-li Lead a session that will advance Internet Freedom by starting important conversations, promoting knowledge exchange, and/or building skills and capacity.
       %li.form-li Follow the <b>IFF Format Template​ </b>and encourage the use of the <b>IFF Session Role Cards​</b> (provided once accepted).
       %li.form-li Respect diversity of opinions, experiences and backgrounds. Please review our <a target="_blank" href="https://internetfreedomfestival.org/wiki/index.php/Code_of_Conduct">Code of Conduct</a>
-      %li.form-li Promote collaboration by inviting different projects or individuals to work on your session, and foster new connections between participants.
+      %li.form-li Promote collaboration by inviting different projects or individuals to work on your session.
       %li.form-li Foster new connections between participants.
       %li.form-li Design your session to fit under one of the IFF Themes (see below), and limit the time to 45 minutes, or 90 minutes for workshops.
 


### PR DESCRIPTION
Hey people!
Thank you for putting together the community platform!

I read through the presenter instructions before submitting my session (which I now procrastinate to write this :smirk: ) and noticed there is a duplicated sentence in the bullet points, which feels like a mistake.
If that's by design though, please ignore this! 

Have a great day!